### PR TITLE
Import only needed S3 service and not whole AWS reference lib

### DIFF
--- a/lambda-functions/thumbnail/index.js
+++ b/lambda-functions/thumbnail/index.js
@@ -1,11 +1,13 @@
 // dependencies
-const s3 = require('aws-sdk/clients/s3');
+const S3 = require('aws-sdk/clients/s3');
 const gm = require('gm').subClass({imageMagick: true}); // Enable ImageMagick integration.
 const util = require('util');
 
 // constants
 const MAX_WIDTH = 250;
 const MAX_HEIGHT = 250;
+
+const s3 = new S3();
 
 /**
  * Generate a thumbnail of an image stored in s3 and store the thumbnail back in the same bucket under the "Thumbnail/" prefix

--- a/lambda-functions/thumbnail/index.js
+++ b/lambda-functions/thumbnail/index.js
@@ -1,14 +1,11 @@
 // dependencies
-const AWS = require('aws-sdk');
+const s3 = require('aws-sdk/clients/s3');
 const gm = require('gm').subClass({imageMagick: true}); // Enable ImageMagick integration.
 const util = require('util');
 
 // constants
 const MAX_WIDTH = 250;
 const MAX_HEIGHT = 250;
-
-// get reference to S3 client
-const s3 = new AWS.S3();
 
 /**
  * Generate a thumbnail of an image stored in s3 and store the thumbnail back in the same bucket under the "Thumbnail/" prefix


### PR DESCRIPTION
- Import only needed S3 service and not whole AWS reference lib in order to avoid large in memory reference of whole AWS SDK